### PR TITLE
Add urls to action payload for context

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -34,7 +34,7 @@ export default fetchAction
  * @returns Promise
  */
 
-function runFetch ({
+export function runFetch ({
   options = {},
   retry = false,
   url
@@ -57,7 +57,7 @@ function runFetch ({
         : response)
 }
 
-function runFetchAction ({
+export function runFetchAction ({
   next,
   options = {},
   retry = false,
@@ -77,7 +77,7 @@ function runFetchAction ({
  * @returns Promise
  */
 
-function runFetchMultiple ({
+export function runFetchMultiple ({
   fetches,
   next
 }, state) {


### PR DESCRIPTION
So we can see in the logger what url was just dispatched (since the fetch action will not actually show up).