### PR TITLE
feat(store): add redux-thunk to support datatools

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-router-redux": "^4.0.7",
     "redux": "^3.6.0",
     "redux-actions": "^1.2.1",
-    "redux-logger": "^2.7.4"
+    "redux-logger": "^2.7.4",
+    "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
     "enzyme": "^2.7.1",

--- a/src/store/store.development.js
+++ b/src/store/store.development.js
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router'
 import {routerMiddleware} from 'react-router-redux'
 import {applyMiddleware, createStore} from 'redux'
 import createLogger from 'redux-logger'
+import thunkMiddleware from 'redux-thunk'
 
 import {middleware as fetch} from '../fetch'
 import multi from './multi'
@@ -21,7 +22,8 @@ export default function configureStore (rootReducer, initialState) {
       fetch,
       multi,
       promise,
-      logger
+      logger,
+      thunkMiddleware
     )
   )
 }

--- a/src/store/store.development.js
+++ b/src/store/store.development.js
@@ -22,8 +22,8 @@ export default function configureStore (rootReducer, initialState) {
       fetch,
       multi,
       promise,
-      logger,
-      thunkMiddleware
+      thunkMiddleware,
+      logger
     )
   )
 }

--- a/src/store/store.production.js
+++ b/src/store/store.production.js
@@ -13,10 +13,10 @@ export default function configureStore (rootReducer, initialState) {
     initialState,
     applyMiddleware(
       routerMiddleware(browserHistory),
-      thunkMiddleware,
       fetch,
       multi,
-      promise
+      promise,
+      thunkMiddleware
     )
   )
 }

--- a/src/store/store.production.js
+++ b/src/store/store.production.js
@@ -1,6 +1,7 @@
 import {browserHistory} from 'react-router'
 import {routerMiddleware} from 'react-router-redux'
 import {applyMiddleware, createStore} from 'redux'
+import thunkMiddleware from 'redux-thunk'
 
 import {middleware as fetch} from '../fetch'
 import multi from './multi'
@@ -12,6 +13,7 @@ export default function configureStore (rootReducer, initialState) {
     initialState,
     applyMiddleware(
       routerMiddleware(browserHistory),
+      thunkMiddleware,
       fetch,
       multi,
       promise

--- a/yarn.lock
+++ b/yarn.lock
@@ -5569,6 +5569,10 @@ redux-mock-store@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.2.tgz#38007dc38f12ca8d965c7521afee5ccacc234d03"
 
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
+
 redux@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"


### PR DESCRIPTION
Add `redux-thunk` to fix #49.