### PR TITLE
Add ability to cancel fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ store.dispatch(fetch({
     throw new Error('Will not be called')
   }
 }))
-store.dispatch(fetch(abortFetch({id})))
+store.dispatch(abortFetch({id}))
 ```
 
 ### fetchMultiple

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ function mapDispatchToProps (dispatch) {
 
 ### fetch
 
-`fetch({url, options, next, retry})`
+`fetch({url, options, next, retry, type, id})`
 
 Create a fetch action to be dispatched by the store. Key features:
 
@@ -97,6 +97,8 @@ Create a fetch action to be dispatched by the store. Key features:
 * `Authorization`, `Content-Type` and `Accept` headers are added automatically (if you want to make a request
    without one of these headers, for instance suppressing the Authorization header when calling a
    remote service, simply set it to null in the `headers` field of `options`).
+* `type` is a string that can designate a category of fetches that will only run one at a time.
+* `id` can be used to later abort the specific fetch by dispatching an `abortFetch` action.
 
 #### fetch errors
 
@@ -127,6 +129,23 @@ store.dispatch(fetch({
     return actionBasedOn(response)
   }
 }))
+```
+
+#### abort fetch
+
+Abort a fetch by dispatching `abortFetch({type, id})`.
+
+```js
+const fetch, {abortFetch, getID} = require('@conveyal/woonerf/fetch')
+const id = getID()
+store.dispatch(fetch({
+  url: 'http://conveyal.com',
+  id,
+  next: () => {
+    throw new Error('Will not be called')
+  }
+}))
+store.dispatch(fetch(abortFetch({id})))
 ```
 
 ### fetchMultiple

--- a/__tests__/src/__snapshots__/fetch.js.snap
+++ b/__tests__/src/__snapshots__/fetch.js.snap
@@ -4,16 +4,14 @@ exports[`fetch should not dispatch a fetchError if the arity of \`next\` is >= 2
 Array [
   Object {
     "payload": Object {
+      "_id": 9,
       "options": Object {},
       "url": "http://fakeurl.com",
     },
     "type": "increment outstanding fetches",
   },
   Object {
-    "payload": Object {
-      "options": Object {},
-      "url": "http://fakeurl.com",
-    },
+    "payload": 9,
     "type": "decrement outstanding fetches",
   },
 ]

--- a/__tests__/src/__snapshots__/fetch.js.snap
+++ b/__tests__/src/__snapshots__/fetch.js.snap
@@ -4,14 +4,18 @@ exports[`fetch should not dispatch a fetchError if the arity of \`next\` is >= 2
 Array [
   Object {
     "payload": Object {
-      "_id": 9,
+      "id": 9,
       "options": Object {},
+      "type": "__FETCH__",
       "url": "http://fakeurl.com",
     },
     "type": "increment outstanding fetches",
   },
   Object {
-    "payload": 9,
+    "payload": Object {
+      "id": 9,
+      "type": "__FETCH__",
+    },
     "type": "decrement outstanding fetches",
   },
 ]

--- a/__tests__/src/fetch.js
+++ b/__tests__/src/fetch.js
@@ -104,25 +104,25 @@ describe('fetch', () => {
   })
 
   it('should fetch multiple urls in one go', (done) => {
-    const store = createstore()
-    nock(url)
+    const store = createStore()
+    nock(URL)
       .get('/one')
       .reply(200, 'one', {'content-type': 'text/plain'})
 
-    nock(url)
+    nock(URL)
       .get('/two')
       .reply(200, 'two', {'content-type': 'text/plain'})
 
-    const action = fetchmultiple({
+    const action = fetchMultiple({
       fetches: [{
-        url: `${url}/one`
+        url: `${URL}/one`
       }, {
-        url: `${url}/two`
+        url: `${URL}/two`
       }],
       next: (error, responses) => {
-        expect(responses.length).tobe(2)
-        expect(responses[0].value).tobe('one')
-        expect(responses[1].value).tobe('two')
+        expect(responses.length).toBe(2)
+        expect(responses[0].value).toBe('one')
+        expect(responses[1].value).toBe('two')
         done(error)
       }
     })

--- a/__tests__/src/fetch.js
+++ b/__tests__/src/fetch.js
@@ -104,25 +104,25 @@ describe('fetch', () => {
   })
 
   it('should fetch multiple urls in one go', (done) => {
-    const store = createStore()
-    nock(URL)
+    const store = createstore()
+    nock(url)
       .get('/one')
-      .reply(200, 'one', {'Content-Type': 'text/plain'})
+      .reply(200, 'one', {'content-type': 'text/plain'})
 
-    nock(URL)
+    nock(url)
       .get('/two')
-      .reply(200, 'two', {'Content-Type': 'text/plain'})
+      .reply(200, 'two', {'content-type': 'text/plain'})
 
-    const action = fetchMultiple({
+    const action = fetchmultiple({
       fetches: [{
-        url: `${URL}/one`
+        url: `${url}/one`
       }, {
-        url: `${URL}/two`
+        url: `${url}/two`
       }],
       next: (error, responses) => {
-        expect(responses.length).toBe(2)
-        expect(responses[0].value).toBe('one')
-        expect(responses[1].value).toBe('two')
+        expect(responses.length).tobe(2)
+        expect(responses[0].value).tobe('one')
+        expect(responses[1].value).tobe('two')
         done(error)
       }
     })
@@ -228,7 +228,7 @@ describe('fetch', () => {
     setTimeout(() => {
       expect(store.getActions()).toMatchSnapshot() // no fetch error action
       done()
-    }, 100)
+    }, 10)
   })
 
   describe('abort', () => {
@@ -259,6 +259,51 @@ describe('fetch', () => {
         })
         done()
       }, 2)
+    })
+
+    it('should not call next on aborted fetchMultiple', (done) => {
+      const store = createStore()
+      nock(URL)
+        .get('/one')
+        .delay(1)
+        .reply(200)
+
+      nock(URL)
+        .get('/two')
+        .delay(1)
+        .reply(200)
+
+      const type = 'TEST'
+
+      store.dispatch(fetchMultiple({
+        type,
+        fetches: [{
+          url: `${URL}/one`
+        }, {
+          url: `${URL}/two`
+        }],
+        next: () => done('should not be called')
+      }))
+      store.dispatch(abortFetch({type}))
+      done()
+    })
+
+    it('should not pass an error on an aborted fetch', (done) => {
+      const store = createStore()
+      const type = 'TEST'
+      nock(URL)
+        .get('/')
+        .delay(1)
+        .replyWithError('ERROR')
+
+      store.dispatch(fetch({
+        url: URL,
+        type,
+        next: (error, response) => done('should not be called')
+      }))
+
+      store.dispatch(abortFetch({type}))
+      done()
     })
 
     it('should call next if fetch finishes before abort', (done) => {

--- a/__tests__/src/fetch.js
+++ b/__tests__/src/fetch.js
@@ -230,7 +230,7 @@ describe('fetch', () => {
     }, 100)
   })
 
-  describe.only('abort', () => {
+  describe('abort', () => {
     it('should not call next on a aborted fetch', (done) => {
       const _id = getID()
       const store = createStore()

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "@conveyal/woonerf",
   "description": "React/Redux bootstrapping and common libs for Conveyal",
   "main": "index.js",
-  "engines": {
-    "node": ">=8"
-  },
   "repository": {
     "url": "https://github.com/conveyal/woonerf",
     "type": "git"

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -74,9 +74,9 @@ export const decrementFetches = (_id) => {
 export function middleware (store) {
   return (next) => (action) => {
     if (action.type === FETCH) {
-      return store.dispatch(runFetchAction(action.payload, store))
+      return store.dispatch(runFetchAction(action.payload, store.getState()))
     } else if (action.type === FETCH_MULTIPLE) {
-      return store.dispatch(runFetchMultiple(action.payload, store))
+      return store.dispatch(runFetchMultiple(action.payload, store.getState()))
     } else {
       return next(action)
     }

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -30,7 +30,7 @@ const removeFetch = (sig) => {
 }
 
 // Check if a fetch is still active
-const isActive = (sig) => {
+export const isActive = (sig) => {
   if (sig.type === GFT) return activeFetches[GFT].includes(sig.id)
   if (activeFetches[sig.type] === undefined) return false
   if (sig.id === undefined) return true
@@ -49,12 +49,15 @@ export const FETCH_ERROR = 'fetch error'
 // Simple action creator
 const createAction = (type) => (payload) => ({type, payload})
 
-// Actions ready for a payload
-export const abortedFetch = createAction(ABORTED_FETCH)
-export const abortFetchFailed = createAction(ABORT_FETCH_FAILED)
+// Main actions to be dispatched
 export const fetchAction = createAction(FETCH)
 export const fetchMultiple = createAction(FETCH_MULTIPLE)
-export const fetchError = createAction(FETCH_ERROR)
+export default fetchAction
+
+// Internally dispatched actions
+const abortedFetch = createAction(ABORTED_FETCH)
+const abortFetchFailed = createAction(ABORT_FETCH_FAILED)
+const fetchError = createAction(FETCH_ERROR)
 
 /**
  * Call decrement and dispatch "aborted" and "decrement" actions. If `id` is
@@ -87,8 +90,11 @@ export const abortAllFetches = () =>
     }
   }, [])
 
-// Send an increment action and add the id to active
-export const incrementFetches = (payload) => {
+/**
+ * Send an increment action and add the fetch to the active list. This will also
+ * abort a previous fetch of the same type if it exists.
+ */
+const incrementFetches = (payload) => {
   const actions = [{
     type: INCREMENT_FETCH,
     payload
@@ -108,8 +114,10 @@ export const incrementFetches = (payload) => {
   return actions
 }
 
-// Send a decrement action and remove the id from active
-export const decrementFetches = (signature) => {
+/**
+ * Send a decrement action and remove the fetch from the active list.
+ */
+const decrementFetches = (signature) => {
   removeFetch(signature)
 
   return {
@@ -130,15 +138,13 @@ export const middleware = (store) => (next) => (action) => {
   }
 }
 
-export default fetchAction
-
 /**
  * Calls fetch, adds Auth and Content header if needed. Automatically parses
  * content based on type.
  *
  * @returns Promise
  */
-export function runFetch ({
+function runFetch ({
   signature,
   options = {},
   retry = false,
@@ -175,7 +181,7 @@ export function runFetch ({
 /**
  * Part of Redux action cycle. Returns an array of actions.
  */
-export function runFetchAction ({
+function runFetchAction ({
   type = GFT,
   id = getID(),
   next,
@@ -222,7 +228,7 @@ export function runFetchAction ({
 /**
  * @returns Array of actions
  */
-export function runFetchMultiple ({
+function runFetchMultiple ({
   type = GFT,
   id = getID(), // One ID for all fetch IDs in a fetch multiple
   fetches,

--- a/src/store/promise.js
+++ b/src/store/promise.js
@@ -5,6 +5,6 @@ function isPromise (val) {
 export default function promiseMiddleware ({dispatch}) {
   return (next) => (action) =>
     isPromise(action)
-      ? action.then(dispatch)
+      ? action.then(results => results && dispatch(results))
       : next(action)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3654,7 +3654,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -5843,13 +5843,6 @@ loglevel-colored-level-prefix@^1.0.0:
 loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
-
-logrocket-react@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/logrocket-react/-/logrocket-react-2.0.0.tgz#efbbf764b7630be44015a73b27ec3a714c51b5af"
-  dependencies:
-    react "16.4.1"
-    react-dom "16.4.1"
 
 logrocket@^0.6.17:
   version "0.6.17"
@@ -8190,15 +8183,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-dom@^16.5.0:
   version "16.5.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.1.tgz#29d0c5a01ed3b6b4c14309aa91af6ec4eb4f292c"
@@ -8247,15 +8231,6 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.5.0:
     prop-types "^15.6.2"
     react-is "^16.5.1"
     schedule "^0.4.0"
-
-react@16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
 
 react@^16.5.0:
   version "16.5.1"


### PR DESCRIPTION
Add two more actions `abortFetch({type, id})` and `abortAllFetches()`. Pass a `type` to fetches to handle duplicates or cancelling types of fetches (on page change) and pass an `id` generated by `woonerf.fetch.getID()` to cancel specific fetches. Only one fetch of a given `type` can be active at a time.

Other breaking changes:
* Only call one increment/decrement for `fetchMultiple`
* `decrementFetches` payload is now an `id` and `type`